### PR TITLE
🐛 Fix import issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,14 +3,13 @@
 import os
 import sys
 
-from plugin.main import RecentProjectsOpen
-
 parent_folder_path = os.path.abspath(os.path.dirname(__file__))
 # add the plugin folder to the sys.path
 sys.path.append(parent_folder_path)
 sys.path.append(os.path.join(parent_folder_path, "lib"))
 sys.path.append(os.path.join(parent_folder_path, "plugin"))
 
+from plugin.main import RecentProjectsOpen
 
 if __name__ == "__main__":
     RecentProjectsOpen()

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -2,12 +2,8 @@ import logging
 import subprocess
 import sys
 import webbrowser
-from os.path import abspath, dirname, join
 
 from flowlauncher import FlowLauncher
-
-parent_folder_path = abspath(dirname(dirname(__file__)))
-sys.path.append(join(parent_folder_path, "plugin"))
 
 from jsonrpc import JsonRPCClient  # noqa: E402
 from log_config import setup_logging  # noqa: E402


### PR DESCRIPTION
Currently the plugin will alert "ModuleNotFoundError: No module named 'flowlauncher'".

The issue is caused by importing the libs before the path adding, so we need to change the position of importing plugin.main. And there's no need to add path again in the plugin/main.py.